### PR TITLE
#7 - vortex: SVG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,17 +4,23 @@
 .PHONY: lint venv src
 
 install:
-	@apt-get -y install python3-pip
-	@apt-get -y install python-dev
-	@apt-get -y install python3-dev
-	@apt-get install python3-setuptools
-	@apt-get install python-setuptools
-	@apt-get install libjpeg-dev zlib1g-dev
-	@pip3 install Pillow
-	@pip3 install wiringpi
+	@apt-get -y -qq install python3-pip
+	@apt-get -y -qq install python-dev
+	@apt-get -y -qq install python3-dev
+	@apt-get -y -qq install python3-setuptools
+	@apt-get -y -qq install python-setuptools
+	@apt-get -y -qq install libjpeg-dev zlib1g-dev
+	@apt-get -y -qq install libcairo2-dev
+	@apt-get -y -qq install pkg-config
+	@apt-get -y -qq install cairosvg
+
+	@pip3 -q install Pillow
+	@pip3 -q install wiringpi
+	@pip3 -q install pycairo
+	@pip3 -q install inky[rpi]
+
 	@git clone https://github.com/doceme/py-spidev.git
 	@(cd py-spidev; make ; make install)
-	@pip3 install inky[rpi]
 
 clobber:
 	@sudo rm -rf ./py-spidev


### PR DESCRIPTION
This commit adds pycairo and dependencies to the install process, and tries to make it as quiet as possible.

 Still pretty noisy.

We need this to develop SVG display applications.